### PR TITLE
refactor(processor): add extension for a TypeElement's stringified binary name

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 kotlin.code.style=official
 group=io.github.eventhorizonlab
-baseVersion=0.1.19
+baseVersion=0.1.20
 org.gradle.jvmargs=-Xmx2g -Dfile.encoding=UTF-8

--- a/modules/processor/build.gradle
+++ b/modules/processor/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     testImplementation 'io.kotest:kotest-framework-engine:6.0.1'
     testImplementation 'io.kotest:kotest-assertions-core:6.0.1'
     testImplementation "dev.zacsweers.kctfork:core:0.8.0"
+    testImplementation "io.mockk:mockk:1.14.5"
 }
 
 var args = [

--- a/modules/processor/src/main/kotlin/com/github/eventhorizonlab/spi/ServiceSchemeProcessor.kt
+++ b/modules/processor/src/main/kotlin/com/github/eventhorizonlab/spi/ServiceSchemeProcessor.kt
@@ -1,5 +1,6 @@
 package com.github.eventhorizonlab.spi
 
+import com.github.eventhorizonlab.spi.extensions.getStringifiedBinaryName
 import com.google.auto.service.AutoService
 import java.lang.annotation.Repeatable
 import javax.annotation.processing.*
@@ -116,8 +117,8 @@ class ServiceSchemeProcessor : AbstractProcessor() {
 
     private fun addProvider(providerElement: TypeElement, contractElement: TypeElement) {
         val contractCanonical = contractElement.qualifiedName.toString()
-        val contractBinary = processingEnv.elementUtils.getBinaryName(contractElement).toString()
-        val providerBinary = processingEnv.elementUtils.getBinaryName(providerElement).toString()
+        val contractBinary = processingEnv.getStringifiedBinaryName(contractElement)
+        val providerBinary = processingEnv.getStringifiedBinaryName(providerElement)
 
         providers += ProviderInfo(contractCanonical, contractBinary, providerBinary)
     }

--- a/modules/processor/src/main/kotlin/com/github/eventhorizonlab/spi/extensions/ProcessingEnvironmentExtensions.kt
+++ b/modules/processor/src/main/kotlin/com/github/eventhorizonlab/spi/extensions/ProcessingEnvironmentExtensions.kt
@@ -1,0 +1,7 @@
+package com.github.eventhorizonlab.spi.extensions
+
+import javax.annotation.processing.ProcessingEnvironment
+import javax.lang.model.element.TypeElement
+
+internal fun ProcessingEnvironment.getStringifiedBinaryName(type: TypeElement) =
+    elementUtils.getBinaryName(type).toString()

--- a/modules/processor/src/test/kotlin/com/github/eventhorizonlab/spi/extensions/ProcessingEnvironmentExtensionsTests.kt
+++ b/modules/processor/src/test/kotlin/com/github/eventhorizonlab/spi/extensions/ProcessingEnvironmentExtensionsTests.kt
@@ -1,0 +1,84 @@
+package com.github.eventhorizonlab.spi.extensions
+
+import com.tschuchort.compiletesting.KotlinCompilation
+import com.tschuchort.compiletesting.SourceFile
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.datatest.withData
+import io.kotest.matchers.shouldBe
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+import javax.annotation.processing.AbstractProcessor
+import javax.annotation.processing.ProcessingEnvironment
+import javax.annotation.processing.RoundEnvironment
+import javax.lang.model.element.TypeElement
+
+@OptIn(ExperimentalCompilerApi::class)
+class ProcessingEnvironmentExtensionsTests : FunSpec({
+
+    data class Case(
+        val description: String,
+        val source: SourceFile,
+        val fqName: String,
+        val expectedBinaryName: String
+    )
+
+    val cases = listOf(
+        Case(
+            "Top-level Kotlin class",
+            SourceFile.kotlin("TopLevel.kt", """
+                package com.test
+                class TopLevel
+            """.trimIndent()),
+            fqName = "com.test.TopLevel",
+            expectedBinaryName = "com.test.TopLevel"
+        ),
+        Case(
+            "Nested Kotlin class",
+            SourceFile.kotlin("Outer.kt", """
+                package com.test
+                class Outer {
+                    class Inner
+                }
+            """.trimIndent()),
+            fqName = "com.test.Outer.Inner",
+            expectedBinaryName = $$"com.test.Outer$Inner"
+        ),
+        Case(
+            "Inner (non-static) Java class",
+            SourceFile.java("OuterJava.java", """
+                package com.test;
+                public class OuterJava {
+                    public class InnerJava {}
+                }
+            """.trimIndent()),
+            fqName = "com.test.OuterJava.InnerJava",
+            expectedBinaryName = $$"com.test.OuterJava$InnerJava"
+        )
+    )
+
+    withData(nameFn = { it.description }, cases) { case ->
+        var actual: String? = null
+
+        val processor = object : AbstractProcessor() {
+            override fun init(processingEnv: ProcessingEnvironment) {
+                super.init(processingEnv)
+                val type = processingEnv.elementUtils.getTypeElement(case.fqName)
+                if (type != null) {
+                    actual = processingEnv.getStringifiedBinaryName(type)
+                }
+            }
+            override fun process(
+                annotations: MutableSet<out TypeElement>,
+                roundEnv: RoundEnvironment
+            ) = false
+        }
+
+        val result = KotlinCompilation().apply {
+            sources = listOf(case.source)
+            annotationProcessors = listOf(processor)
+            inheritClassPath = true
+        }.compile()
+
+        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        actual shouldBe case.expectedBinaryName
+    }
+})


### PR DESCRIPTION
## 📌 Summary
<!-- Briefly describe the purpose of this PR and what it changes. -->
Adds an extension method to simplify getting a stringified binary name for a TypeElement via ProcessingEnvironment

## 🔍 Related Issues / Tickets
<!-- Link to any related issues, discussions, or tickets. -->
- Closes #3

## 🛠 Changes in Detail
<!-- List the key changes in this PR. -->
- Adds `ProcessingEnvironment.getStringifiedBinaryName(TypeElement)`
- Adds test suite which verifies the behaviour of this method

## 🧩 Modules Affected
<!-- Tick all modules that are impacted by this change. -->
- [ ] spi-tooling-annotations
- [x] spi-tooling-processor
- [ ] Other:

## 📦 Versioning
<!-- 
If this PR is intended for a release:
- Ensure `version` in gradle.properties is greater than main.
If this PR is for a test snapshot:
- No manual version bump needed; CI will append `-SNAPSHOT-<pr>-<increment>`.
-->
- [x] Version bump applied (release PR)
- [x] Snapshot only (PR build)

## 🧪 Testing
<!-- Describe how you tested your changes and how reviewers can reproduce them. -->
- Steps:
    1. Created in-memory source files for different class shapes (top-level Kotlin, nested Kotlin, inner Java) using `SourceFile.kotlin` and `SourceFile.java`
    2. Compiled them in-memory with `kotlin-compile-testing`, attaching a custom `AbstractProcessor` that:
      - Receives a real `ProcessingEnvironment` from the compiler
      - Looks up the `TypeElement` for each case by its fully-qualified name (`fqName`)
      - Calls the extension function `getStringifiedBinaryName` under test
    3. Captured the result from the processor's `init` method
    4. Asserted that the returned binary name matches the expected JVM binary name for that class shape (e.g. `com.test.Outer$Inner` for a nested class)
    5. Ran the suite parameterised with Kotest's `withData` so each case is compiled and tested independently

Steps to reproduce locally:
1. Check out the branch
2. Run `./gradlew kotest`
3. Observe that all parameterised cases pass, confirming the extension works for both Kotlin and Java classes in different nesting configurations

## ✅ Checklist
- [x] Code builds locally without errors
- [x] All tests pass locally (`./gradlew kotest`)
- [x] Added/updated tests for new or changed logic
- [x] Updated documentation / README if needed
- [x] No unrelated changes included

## 📜 Notes for Reviewers
<!-- Any extra context, caveats, or follow-up work for reviewers. -->
