### PR TITLE
feat(processor): allow contracts with no providers

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 kotlin.code.style=official
 group=io.github.eventhorizonlab
-baseVersion=0.1.20
+baseVersion=0.1.21
 org.gradle.jvmargs=-Xmx2g -Dfile.encoding=UTF-8

--- a/modules/annotations/src/main/kotlin/com/github/eventhorizonlab/spi/ServiceScheme.kt
+++ b/modules/annotations/src/main/kotlin/com/github/eventhorizonlab/spi/ServiceScheme.kt
@@ -9,7 +9,9 @@ import kotlin.reflect.KClass
 @MustBeDocumented
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.RUNTIME)
-annotation class ServiceProvider(vararg val value: KClass<*>)
+annotation class ServiceProvider(
+    vararg val value: KClass<*>,
+)
 
 /**
  * Marks an interface as a ServiceLoader contract.

--- a/modules/processor/src/main/kotlin/com/github/eventhorizonlab/spi/ServiceSchemeProcessor.kt
+++ b/modules/processor/src/main/kotlin/com/github/eventhorizonlab/spi/ServiceSchemeProcessor.kt
@@ -15,41 +15,45 @@ import javax.tools.Diagnostic
 import javax.tools.StandardLocation
 
 private data class ProviderInfo(
-    val contractCanonical: String, val contractBinary: String, val providerBinary: String
+    val contractCanonical: String,
+    val contractBinary: String,
+    val providerBinary: String,
 )
 
 @SupportedOptions("org.gradle.annotation.processing.aggregating")
 @AutoService(Processor::class)
 @SupportedSourceVersion(SourceVersion.RELEASE_24)
 class ServiceSchemeProcessor : AbstractProcessor() {
-
-    override fun getSupportedAnnotationTypes() = setOf(
-        ServiceProvider::class.java.canonicalName, ServiceContract::class.java.canonicalName
-    )
+    override fun getSupportedAnnotationTypes() =
+        setOf(
+            ServiceProvider::class.java.canonicalName,
+            ServiceContract::class.java.canonicalName,
+        )
 
     private val contracts = mutableSetOf<String>() // canonical names
     private val providers = mutableListOf<ProviderInfo>()
 
     override fun process(
-        annotations: MutableSet<out TypeElement>, roundEnv: RoundEnvironment
+        annotations: MutableSet<out TypeElement>,
+        roundEnv: RoundEnvironment,
     ): Boolean {
-        // 1) Collect contracts defined in this compilation
-        roundEnv.getElementsAnnotatedWith(ServiceContract::class.java).filter { it.kind == ElementKind.INTERFACE }
-            .map { (it as TypeElement).qualifiedName.toString() }.forEach { contracts += it }
+        // 1) Collect contracts
+        roundEnv
+            .getElementsAnnotatedWith(ServiceContract::class.java)
+            .filter { it.kind == ElementKind.INTERFACE }
+            .map { (it as TypeElement).qualifiedName.toString() }
+            .forEach { contracts += it }
 
         // 2) Collect providers
         roundEnv.getElementsAnnotatedWith(ServiceProvider::class.java).forEach { element ->
-            // 1) Collect all ServiceProvider mirrors (direct + from container if repeatable)
             val spMirrors = collectServiceProviderMirrors(element, processingEnv)
-
-            // 2) For each ServiceProvider mirror, read its "value" (array of class literals)
             spMirrors.forEach { spMirror ->
                 val valuesWithDefaults = processingEnv.elementUtils.getElementValuesWithDefaults(spMirror)
                 val valueAv =
-                    valuesWithDefaults.entries.firstOrNull { it.key.simpleName.contentEquals("value") }?.value ?: error(
-                        "@ServiceProvider missing 'value' on ${element.simpleName}"
-                    )
-
+                    valuesWithDefaults.entries
+                        .firstOrNull { it.key.simpleName.contentEquals("value") }
+                        ?.value
+                        ?: error("@ServiceProvider missing 'value' on ${element.simpleName}")
                 val typeMirrors = classArrayAnnotationValues(valueAv, processingEnv)
                 typeMirrors.forEach { tm ->
                     val contractElement = (tm as DeclaredType).asElement() as TypeElement
@@ -58,10 +62,13 @@ class ServiceSchemeProcessor : AbstractProcessor() {
             }
         }
 
-        // 3) On final round, generate files + validate
+        // 3) Validate implementations every round (so we catch missing @ServiceProvider)
+        validateImplementations(roundEnv)
+
+        // 4) On final round, generate files + validate provider targets
         if (roundEnv.processingOver()) {
             generateServiceFiles()
-            validateProviders()
+            validateProviderTargets()
         }
 
         return true
@@ -73,49 +80,93 @@ class ServiceSchemeProcessor : AbstractProcessor() {
         }
 
         // Flag contracts declared here with no providers
-        contracts.filter { canonical ->
-            providers.none { it.contractCanonical == canonical }
-        }.forEach { contract ->
-            processingEnv.messager.printMessage(
-                Diagnostic.Kind.ERROR, missingServiceProviderErrorMessage(contract)
-            )
-        }
+        contracts
+            .filter { canonical ->
+                providers.none { it.contractCanonical == canonical }
+            }.forEach { contract ->
+                processingEnv.messager.printMessage(
+                    Diagnostic.Kind.WARNING,
+                    "No @ServiceProvider found for contract $contract in this compilation unit. " +
+                        "This may be intentional if this module only defines contracts.",
+                )
+            }
     }
 
-    private fun validateProviders() {
+    private fun validateImplementations(roundEnv: RoundEnvironment) {
+        val contractTypes = contracts.mapNotNull { processingEnv.elementUtils.getTypeElement(it) }
+        val contractTypeMirrors = contractTypes.map { it.asType() }.toSet()
+
+        roundEnv.rootElements
+            .filterIsInstance<TypeElement>()
+            .filter { it.kind == ElementKind.CLASS }
+            .forEach { clazz ->
+                val implementsContract =
+                    contractTypeMirrors.any { ct ->
+                        processingEnv.typeUtils.isAssignable(clazz.asType(), ct)
+                    }
+                val hasServiceProvider =
+                    clazz.annotationMirrors.any {
+                        (it.annotationType.asElement() as TypeElement).qualifiedName.toString() ==
+                            ServiceProvider::class.java.canonicalName
+                    }
+                if (implementsContract && !hasServiceProvider) {
+                    val contractName =
+                        contractTypes
+                            .first {
+                                processingEnv.typeUtils.isAssignable(clazz.asType(), it.asType())
+                            }.qualifiedName
+                            .toString()
+                    processingEnv.messager.printMessage(
+                        Diagnostic.Kind.ERROR,
+                        missingServiceProviderErrorMessage(contractName),
+                    )
+                }
+            }
+    }
+
+    private fun validateProviderTargets() {
         providers.map { it.contractCanonical }.distinct().forEach { canonicalName ->
             val contractElement = processingEnv.elementUtils.getTypeElement(canonicalName)
-            val hasAnnotation = contractElement?.annotationMirrors?.any {
-                val annType = (it.annotationType.asElement() as TypeElement).qualifiedName.toString()
-                annType == ServiceContract::class.java.canonicalName
-            } ?: false
-
+            val hasAnnotation =
+                contractElement?.annotationMirrors?.any {
+                    val annType = (it.annotationType.asElement() as TypeElement).qualifiedName.toString()
+                    annType == ServiceContract::class.java.canonicalName
+                } ?: false
             if (!hasAnnotation) {
-                val hint = if (contractElement == null) {
-                    "Contract type not found — is the API module on the processor's compile classpath?"
-                } else {
-                    "Type is present but not annotated with @ServiceContract."
-                }
+                val hint =
+                    if (contractElement == null) {
+                        "Contract type not found— is the API module on the processor's compile classpath?"
+                    } else {
+                        "Type is present but not annotated with @ServiceContract."
+                    }
                 processingEnv.messager.printMessage(
                     Diagnostic.Kind.ERROR,
-                    "@ServiceProvider target $canonicalName is not annotated with @ServiceContract. $hint"
+                    "@ServiceProvider target $canonicalName is not annotated with @ServiceContract. $hint",
                 )
             }
         }
     }
 
-    private fun writeServiceFile(contractBinary: String, impls: List<String>) {
+    private fun writeServiceFile(
+        contractBinary: String,
+        impls: List<String>,
+    ) {
         processingEnv.messager.printMessage(
             Diagnostic.Kind.NOTE,
-            "Writing META-INF/services/$contractBinary with ${impls.size} implementation(s): ${impls.joinToString()}"
+            "Writing META-INF/services/$contractBinary with ${impls.size} implementation(s): ${impls.joinToString()}",
         )
-        processingEnv.filer.createResource(StandardLocation.CLASS_OUTPUT, "", "META-INF/services/$contractBinary")
-            .openWriter().use { writer ->
+        processingEnv.filer
+            .createResource(StandardLocation.CLASS_OUTPUT, "", "META-INF/services/$contractBinary")
+            .openWriter()
+            .use { writer ->
                 impls.forEach { writer.write("$it\n") }
             }
     }
 
-    private fun addProvider(providerElement: TypeElement, contractElement: TypeElement) {
+    private fun addProvider(
+        providerElement: TypeElement,
+        contractElement: TypeElement,
+    ) {
         val contractCanonical = contractElement.qualifiedName.toString()
         val contractBinary = processingEnv.getStringifiedBinaryName(contractElement)
         val providerBinary = processingEnv.getStringifiedBinaryName(providerElement)
@@ -123,55 +174,68 @@ class ServiceSchemeProcessor : AbstractProcessor() {
         providers += ProviderInfo(contractCanonical, contractBinary, providerBinary)
     }
 
-
     /**
      * Returns all @ServiceProvider annotation mirrors on the element, expanding a repeatable
      * container if present, using only javax.lang.model APIs.
      */
     private fun collectServiceProviderMirrors(
-        element: javax.lang.model.element.Element, processingEnv: ProcessingEnvironment
+        element: javax.lang.model.element.Element,
+        processingEnv: ProcessingEnvironment,
     ): List<AnnotationMirror> {
         val spName = ServiceProvider::class.java.canonicalName
         val spType = processingEnv.elementUtils.getTypeElement(spName) ?: return emptyList()
 
         // Find container type from @Repeatable, if any
-        val containerName = spType.annotationMirrors.firstNotNullOfOrNull { am ->
-            val annType = (am.annotationType.asElement() as TypeElement).qualifiedName.toString()
-            if (annType == Repeatable::class.java.canonicalName) {
-                // @Repeatable(value = Container.class)
-                val values = processingEnv.elementUtils.getElementValuesWithDefaults(am)
-                val repeatableValueAv = values.entries.first { it.key.simpleName.contentEquals("value") }.value
-                val containerTm = repeatableValueAv.value as TypeMirror
-                ((containerTm as DeclaredType).asElement() as TypeElement).qualifiedName.toString()
-            } else null
-        }
-
-        val direct = element.annotationMirrors.filter { m ->
-            ((m.annotationType.asElement() as TypeElement).qualifiedName.toString() == spName)
-        }
-
-        val expandedFromContainer = if (containerName != null) {
-            element.annotationMirrors.filter { (it.annotationType.asElement() as TypeElement).qualifiedName.toString() == containerName }
-                .flatMap { containerMirror ->
-                    // Container has a "value" which is an array of nested @ServiceProvider annotations
-                    val values = processingEnv.elementUtils.getElementValuesWithDefaults(containerMirror)
-                    val valueAv = values.entries.firstOrNull { it.key.simpleName.contentEquals("value") }?.value
-                        ?: return@flatMap emptyList()
-                    val arr = valueAv.value as List<*>
-                    arr.filterIsInstance<AnnotationValue>().mapNotNull { it.value as? AnnotationMirror }
+        val containerName =
+            spType.annotationMirrors.firstNotNullOfOrNull { am ->
+                val annType = (am.annotationType.asElement() as TypeElement).qualifiedName.toString()
+                if (annType == Repeatable::class.java.canonicalName) {
+                    // @Repeatable(value = Container.class)
+                    val values = processingEnv.elementUtils.getElementValuesWithDefaults(am)
+                    val repeatableValueAv = values.entries.first { it.key.simpleName.contentEquals("value") }.value
+                    val containerTm = repeatableValueAv.value as TypeMirror
+                    ((containerTm as DeclaredType).asElement() as TypeElement).qualifiedName.toString()
+                } else {
+                    null
                 }
-        } else emptyList()
+            }
+
+        val direct =
+            element.annotationMirrors.filter { m ->
+                ((m.annotationType.asElement() as TypeElement).qualifiedName.toString() == spName)
+            }
+
+        val expandedFromContainer =
+            if (containerName != null) {
+                element.annotationMirrors
+                    .filter { (it.annotationType.asElement() as TypeElement).qualifiedName.toString() == containerName }
+                    .flatMap { containerMirror ->
+                        // Container has a "value" which is an array of nested @ServiceProvider annotations
+                        val values = processingEnv.elementUtils.getElementValuesWithDefaults(containerMirror)
+                        val valueAv =
+                            values.entries.firstOrNull { it.key.simpleName.contentEquals("value") }?.value
+                                ?: return@flatMap emptyList()
+                        val arr = valueAv.value as List<*>
+                        arr.filterIsInstance<AnnotationValue>().mapNotNull { it.value as? AnnotationMirror }
+                    }
+            } else {
+                emptyList()
+            }
 
         return direct + expandedFromContainer
     }
 
-    private fun toTypeMirror(raw: Any?, processingEnv: ProcessingEnvironment): TypeMirror? = when (raw) {
-        null -> null
-        is TypeMirror -> raw
-        is AnnotationValue -> toTypeMirror(raw.value, processingEnv)
-        is String -> processingEnv.elementUtils.getTypeElement(raw)?.asType()
-        else -> null
-    }
+    private fun toTypeMirror(
+        raw: Any?,
+        processingEnv: ProcessingEnvironment,
+    ): TypeMirror? =
+        when (raw) {
+            null -> null
+            is TypeMirror -> raw
+            is AnnotationValue -> toTypeMirror(raw.value, processingEnv)
+            is String -> processingEnv.elementUtils.getTypeElement(raw)?.asType()
+            else -> null
+        }
 
     /**
      * Converts the "value" of a class[] annotation member into a List<TypeMirror>,
@@ -179,14 +243,12 @@ class ServiceSchemeProcessor : AbstractProcessor() {
      */
     private fun classArrayAnnotationValues(
         valueAv: AnnotationValue,
-        processingEnv: ProcessingEnvironment
-    ): List<TypeMirror> {
-        return when (val raw = valueAv.value) {
+        processingEnv: ProcessingEnvironment,
+    ): List<TypeMirror> =
+        when (val raw = valueAv.value) {
             is List<*> -> raw.mapNotNull { toTypeMirror(it, processingEnv) }
             else -> listOfNotNull(toTypeMirror(raw, processingEnv))
         }
-    }
-
 }
 
 internal fun missingServiceProviderErrorMessage(contract: String) = "No @ServiceProvider found for contract $contract"

--- a/modules/processor/src/main/kotlin/com/github/eventhorizonlab/spi/extensions/ProcessingEnvironmentExtensions.kt
+++ b/modules/processor/src/main/kotlin/com/github/eventhorizonlab/spi/extensions/ProcessingEnvironmentExtensions.kt
@@ -3,5 +3,4 @@ package com.github.eventhorizonlab.spi.extensions
 import javax.annotation.processing.ProcessingEnvironment
 import javax.lang.model.element.TypeElement
 
-internal fun ProcessingEnvironment.getStringifiedBinaryName(type: TypeElement) =
-    elementUtils.getBinaryName(type).toString()
+internal fun ProcessingEnvironment.getStringifiedBinaryName(type: TypeElement) = elementUtils.getBinaryName(type).toString()

--- a/modules/processor/src/test/kotlin/com/github/eventhorizonlab/spi/ServiceSchemeProcessorSpec.kt
+++ b/modules/processor/src/test/kotlin/com/github/eventhorizonlab/spi/ServiceSchemeProcessorSpec.kt
@@ -12,635 +12,850 @@ import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import java.io.File
 import java.net.URLClassLoader
 import java.util.ServiceLoader
+import javax.tools.Diagnostic
 
 @OptIn(ExperimentalCompilerApi::class)
-class ServiceSchemeProcessorSpec : FunSpec({
+class ServiceSchemeProcessorSpec :
+    FunSpec({
 
-    // --- Common compile helpers ---
-    fun compile(
-        sources: List<SourceFile>, classpaths: List<File> = emptyList(), runProcessor: Boolean = true
-    ) = KotlinCompilation().apply {
-        this.sources = sources
-        if (runProcessor) {
-            this.annotationProcessors = listOf(ServiceSchemeProcessor())
+        //#region --- Common compile helpers ---
+        fun compile(
+            sources: List<SourceFile>,
+            classpaths: List<File> = emptyList(),
+            runProcessor: Boolean = true,
+        ) = KotlinCompilation()
+            .apply {
+                this.sources = sources
+                if (runProcessor) {
+                    this.annotationProcessors = listOf(ServiceSchemeProcessor())
+                }
+                this.inheritClassPath = true
+                this.classpaths = classpaths
+            }.compile()
+
+        fun compileApi(vararg sources: SourceFile) = compile(sources.toList(), runProcessor = false)
+
+        fun compileImpl(
+            apiResult: JvmCompilationResult,
+            vararg sources: SourceFile,
+        ) = compile(sources.toList(), listOf(apiResult.outputDirectory))
+
+        fun assertServiceFile(
+            result: JvmCompilationResult,
+            contractFqcn: List<String>,
+            vararg expectedImpls: String,
+        ) {
+            contractFqcn.forEach { fqcn ->
+                val lines =
+                    result.classLoader
+                        .readServiceFile(fqcn)
+                        ?.lines()
+                        ?.filter { it.isNotBlank() }
+                        ?.sorted()
+                lines shouldBe expectedImpls.toList().sorted()
+            }
         }
-        this.inheritClassPath = true
-        this.classpaths = classpaths
-    }.compile()
+        //#endregion --- Common compile helpers ---
 
-    fun compileApi(vararg sources: SourceFile) = compile(sources.toList(), runProcessor = false)
+        //#region --- Happy path scenarios ---
+        data class ServiceCase(
+            val description: String,
+            val api: List<SourceFile>,
+            val impls: List<SourceFile>,
+            val contractFqcn: List<String>,
+            val expectedImpls: List<String>,
+        )
 
-    fun compileImpl(apiResult: JvmCompilationResult, vararg sources: SourceFile) =
-        compile(sources.toList(), listOf(apiResult.outputDirectory))
+        context("service generation happy paths") {
+            withData(
+                nameFn = { it.description },
+                // Kotlin API + Kotlin impl (nested)
+                ServiceCase(
+                    "nested provider (Kotlin API + Kotlin impl)",
+                    api =
+                        listOf(
+                            SourceFile.kotlin(
+                                "Api.kt",
+                                """
+                                package my.api
+                                import com.github.eventhorizonlab.spi.ServiceContract
+                                interface Outer {
+                                    @ServiceContract
+                                    interface Inner
+                                }
+                                """.trimIndent(),
+                            ),
+                        ),
+                    impls =
+                        listOf(
+                            SourceFile.kotlin(
+                                "Impl.kt",
+                                """
+                                package my.impl
+                                import my.api.Outer.Inner
+                                import com.github.eventhorizonlab.spi.ServiceProvider
+                                class Impl {
+                                    @ServiceProvider(Inner::class)
+                                    class ImplInner : Inner
+                                }
+                                """.trimIndent(),
+                            ),
+                        ),
+                    contractFqcn = listOf($$"my.api.Outer$Inner"),
+                    expectedImpls = listOf($$"my.impl.Impl$ImplInner"),
+                ),
+                // Kotlin API + Kotlin impl (cross-module)
+                ServiceCase(
+                    "cross-module provider (Kotlin API + Kotlin impl)",
+                    api =
+                        listOf(
+                            SourceFile.kotlin(
+                                "Api.kt",
+                                """
+                                package my.api
+                                import com.github.eventhorizonlab.spi.ServiceContract
+                                @ServiceContract
+                                interface Contract
+                                """.trimIndent(),
+                            ),
+                        ),
+                    impls =
+                        listOf(
+                            SourceFile.kotlin(
+                                "Impl.kt",
+                                """
+                                package my.impl
+                                import my.api.Contract
+                                import com.github.eventhorizonlab.spi.ServiceProvider
+                                @ServiceProvider(Contract::class)
+                                class Impl : Contract
+                                """.trimIndent(),
+                            ),
+                        ),
+                    contractFqcn = listOf("my.api.Contract"),
+                    expectedImpls = listOf("my.impl.Impl"),
+                ),
+                // Kotlin API + Java impl
+                ServiceCase(
+                    "Kotlin API + Java impl",
+                    api =
+                        listOf(
+                            SourceFile.kotlin(
+                                "Api.kt",
+                                """
+                                package my.api
+                                import com.github.eventhorizonlab.spi.ServiceContract
+                                @ServiceContract
+                                interface Api
+                                """.trimIndent(),
+                            ),
+                        ),
+                    impls =
+                        listOf(
+                            SourceFile.java(
+                                "Impl.java",
+                                """
+                                package my.impl;
+                                import my.api.Api;
+                                import com.github.eventhorizonlab.spi.ServiceProvider;
+                                @ServiceProvider(Api.class)
+                                public class Impl implements Api {}
+                                """.trimIndent(),
+                            ),
+                        ),
+                    contractFqcn = listOf("my.api.Api"),
+                    expectedImpls = listOf("my.impl.Impl"),
+                ),
+                // Java API + Kotlin impl
+                ServiceCase(
+                    "Java API + Kotlin impl",
+                    api =
+                        listOf(
+                            SourceFile.java(
+                                "Api.java",
+                                """
+                                package my.api;
+                                import com.github.eventhorizonlab.spi.ServiceContract;
+                                @ServiceContract
+                                public interface Api {}
+                                """.trimIndent(),
+                            ),
+                        ),
+                    impls =
+                        listOf(
+                            SourceFile.kotlin(
+                                "Impl.kt",
+                                """
+                                package my.impl
+                                import my.api.Api
+                                import com.github.eventhorizonlab.spi.ServiceProvider
+                                @ServiceProvider(Api::class)
+                                class Impl : Api
+                                """.trimIndent(),
+                            ),
+                        ),
+                    contractFqcn = listOf("my.api.Api"),
+                    expectedImpls = listOf("my.impl.Impl"),
+                ),
+                // Java API + Java impl
+                ServiceCase(
+                    "Java API + Java impl",
+                    api =
+                        listOf(
+                            SourceFile.java(
+                                "Contract.java",
+                                """
+                                package my.api;
+                                import com.github.eventhorizonlab.spi.ServiceContract;
+                                @ServiceContract
+                                public interface Contract {}
+                                """.trimIndent(),
+                            ),
+                        ),
+                    impls =
+                        listOf(
+                            SourceFile.java(
+                                "Impl.java",
+                                """
+                                package my.impl;
+                                import my.api.Contract;
+                                import com.github.eventhorizonlab.spi.ServiceProvider;
+                                @ServiceProvider(Contract.class)
+                                public class Impl implements Contract {}
+                                """.trimIndent(),
+                            ),
+                        ),
+                    contractFqcn = listOf("my.api.Contract"),
+                    expectedImpls = listOf("my.impl.Impl"),
+                ),
+                // Multiple providers
+                ServiceCase(
+                    "multiple providers for same contract",
+                    api =
+                        listOf(
+                            SourceFile.kotlin(
+                                "Api.kt",
+                                """
+                                package my.api
+                                import com.github.eventhorizonlab.spi.ServiceContract
+                                @ServiceContract
+                                interface Contract
+                                """.trimIndent(),
+                            ),
+                        ),
+                    impls =
+                        listOf(
+                            SourceFile.kotlin(
+                                "Impl1.kt",
+                                """
+                                package my.impl
+                                import my.api.Contract
+                                import com.github.eventhorizonlab.spi.ServiceProvider
+                                @ServiceProvider(Contract::class)
+                                class Impl1 : Contract
+                                """.trimIndent(),
+                            ),
+                            SourceFile.kotlin(
+                                "Impl2.kt",
+                                """
+                                package my.impl
+                                import my.api.Contract
+                                import com.github.eventhorizonlab.spi.ServiceProvider
+                                @ServiceProvider(Contract::class)
+                                class Impl2 : Contract
+                                """.trimIndent(),
+                            ),
+                            SourceFile.java(
+                                "Impl3.java",
+                                """
+                                package my.impl;
+                                import my.api.Contract;
+                                import com.github.eventhorizonlab.spi.ServiceProvider;
+                                @ServiceProvider(Contract.class)
+                                public class Impl3 implements Contract {}
+                                """.trimIndent(),
+                            ),
+                        ),
+                    contractFqcn = listOf("my.api.Contract"),
+                    expectedImpls = listOf("my.impl.Impl1", "my.impl.Impl2", "my.impl.Impl3"),
+                ),
+                ServiceCase(
+                    "provider implements multiple contracts (Kotlin)",
+                    api =
+                        listOf(
+                            SourceFile.kotlin(
+                                "Apis.kt",
+                                """
+                                package my.api
+                                import com.github.eventhorizonlab.spi.ServiceContract
+                                
+                                @ServiceContract
+                                interface Api
+                                
+                                @ServiceContract
+                                interface Api2
+                                """.trimIndent(),
+                            ),
+                        ),
+                    impls =
+                        listOf(
+                            SourceFile.kotlin(
+                                "Impl.kt",
+                                """
+                                package my.impl
+                                import my.api.Api
+                                import my.api.Api2
+                                import com.github.eventhorizonlab.spi.ServiceProvider
+                                @ServiceProvider(Api::class, Api2::class)
+                                class Impl : Api, Api2
+                                """.trimIndent(),
+                            ),
+                        ),
+                    contractFqcn = listOf("my.api.Api", "my.api.Api2"),
+                    expectedImpls = listOf("my.impl.Impl"),
+                ),
+                ServiceCase(
+                    "provider implements multiple contracts (Java)",
+                    api =
+                        listOf(
+                            SourceFile.java(
+                                "Api.java",
+                                """
+                                package my.api;
+                                import com.github.eventhorizonlab.spi.ServiceContract;
+                                @ServiceContract
+                                public interface Api {}
+                                """.trimIndent(),
+                            ),
+                            SourceFile.java(
+                                "Api2.java",
+                                """
+                                package my.api;
+                                import com.github.eventhorizonlab.spi.ServiceContract;
+                                @ServiceContract
+                                public interface Api2 {}
+                                """.trimIndent(),
+                            ),
+                        ),
+                    impls =
+                        listOf(
+                            SourceFile.java(
+                                "Impl.java",
+                                """
+                                package my.impl;
+                                import my.api.Api;
+                                import my.api.Api2;
+                                import com.github.eventhorizonlab.spi.ServiceProvider;
+                                @ServiceProvider({Api.class, Api2.class})
+                                public class Impl implements Api, Api2 {}
+                                """.trimIndent(),
+                            ),
+                        ),
+                    contractFqcn = listOf("my.api.Api", "my.api.Api2"),
+                    expectedImpls = listOf("my.impl.Impl"),
+                ),
+                ServiceCase(
+                    "provider implements multiple contracts (Kotlin+Java)",
+                    api =
+                        listOf(
+                            SourceFile.kotlin(
+                                "Apis.kt",
+                                """
+                                package my.api
+                                import com.github.eventhorizonlab.spi.ServiceContract
+                                @ServiceContract
+                                interface Api
+                                @ServiceContract
+                                interface Api2
+                                """.trimIndent(),
+                            ),
+                        ),
+                    impls =
+                        listOf(
+                            SourceFile.java(
+                                "Impl.java",
+                                """
+                                package my.impl;
+                                import my.api.Api;
+                                import my.api.Api2;
+                                import com.github.eventhorizonlab.spi.ServiceProvider;
+                                @ServiceProvider({Api.class, Api2.class})
+                                public class Impl implements Api, Api2 {}
+                                """.trimIndent(),
+                            ),
+                        ),
+                    contractFqcn = listOf("my.api.Api", "my.api.Api2"),
+                    expectedImpls = listOf("my.impl.Impl"),
+                ),
+                ServiceCase(
+                    "provider implements multiple contracts (Java+Kotlin)",
+                    api =
+                        listOf(
+                            SourceFile.java(
+                                "Api.java",
+                                """
+                                package my.api;
+                                import com.github.eventhorizonlab.spi.ServiceContract;
+                                @ServiceContract
+                                public interface Api {}
+                                """.trimIndent(),
+                            ),
+                            SourceFile.kotlin(
+                                "Api2.kt",
+                                """
+                                package my.api
+                                import com.github.eventhorizonlab.spi.ServiceContract
+                                @ServiceContract
+                                interface Api2
+                                """.trimIndent(),
+                            ),
+                        ),
+                    impls =
+                        listOf(
+                            SourceFile.kotlin(
+                                "Impl.kt",
+                                """
+                                package my.impl
+                                import my.api.Api
+                                import my.api.Api2
+                                import com.github.eventhorizonlab.spi.ServiceProvider
+                                @ServiceProvider(Api::class, Api2::class)
+                                class Impl : Api, Api2
+                                """.trimIndent(),
+                            ),
+                        ),
+                    contractFqcn = listOf("my.api.Api", "my.api.Api2"),
+                    expectedImpls = listOf("my.impl.Impl"),
+                ),
+                ServiceCase(
+                    "Java generic API with Kotlin provider (type erasure check)",
+                    api =
+                        listOf(
+                            SourceFile.java(
+                                "Api.java",
+                                """
+                                package my.api;
+                                import com.github.eventhorizonlab.spi.ServiceContract;
+                                
+                                @ServiceContract
+                                public interface Api<T> {}
+                                """.trimIndent(),
+                            ),
+                        ),
+                    impls =
+                        listOf(
+                            SourceFile.kotlin(
+                                "Impl.kt",
+                                """
+                                package my.impl
+                                import my.api.Api
+                                import com.github.eventhorizonlab.spi.ServiceProvider
+                                
+                                @ServiceProvider(Api::class)
+                                class Impl : Api<String>
+                                """.trimIndent(),
+                            ),
+                        ),
+                    contractFqcn = listOf("my.api.Api"),
+                    expectedImpls = listOf("my.impl.Impl"),
+                ),
+                ServiceCase(
+                    "Kotlin generic API with Java provider (type erasure check)",
+                    api =
+                        listOf(
+                            SourceFile.kotlin(
+                                "Api.kt",
+                                """
+                                package my.api
+                                import com.github.eventhorizonlab.spi.ServiceContract
+                                @ServiceContract
+                                interface Api<T>
+                                """.trimIndent(),
+                            ),
+                        ),
+                    impls =
+                        listOf(
+                            SourceFile.java(
+                                "Impl.java",
+                                """
+                                package my.impl;
+                                import my.api.Api;
+                                import com.github.eventhorizonlab.spi.ServiceProvider;
+                                @ServiceProvider(Api.class)
+                                public class Impl implements Api<String> {}
+                                """.trimIndent(),
+                            ),
+                        ),
+                    contractFqcn = listOf("my.api.Api"),
+                    expectedImpls = listOf("my.impl.Impl"),
+                ),
+                ServiceCase(
+                    "Kotlin API with generic provider (type erasure check)",
+                    api =
+                        listOf(
+                            SourceFile.kotlin(
+                                "Api.kt",
+                                """
+                                package my.api
+                                import com.github.eventhorizonlab.spi.ServiceContract
+                                @ServiceContract
+                                interface Api<T>
+                                """.trimIndent(),
+                            ),
+                        ),
+                    impls =
+                        listOf(
+                            SourceFile.kotlin(
+                                "Impl.kt",
+                                """
+                                package my.impl
+                                import my.api.Api
+                                import com.github.eventhorizonlab.spi.ServiceProvider
+                                @ServiceProvider(Api::class)
+                                class Impl : Api<String>
+                                """.trimIndent(),
+                            ),
+                        ),
+                    contractFqcn = listOf("my.api.Api"),
+                    expectedImpls = listOf("my.impl.Impl"),
+                ),
+                ServiceCase(
+                    "Java API with generic provider (type erasure check)",
+                    api =
+                        listOf(
+                            SourceFile.java(
+                                "Api.java",
+                                """
+                                package my.api;
+                                import com.github.eventhorizonlab.spi.ServiceContract;
+                                @ServiceContract
+                                public interface Api<T> {}
+                                """.trimIndent(),
+                            ),
+                        ),
+                    impls =
+                        listOf(
+                            SourceFile.java(
+                                "Impl.java",
+                                """
+                                package my.impl;
+                                import my.api.Api;
+                                import com.github.eventhorizonlab.spi.ServiceProvider;
+                                @ServiceProvider(Api.class)
+                                public class Impl implements Api<String> {}
+                                """.trimIndent(),
+                            ),
+                        ),
+                    contractFqcn = listOf("my.api.Api"),
+                    expectedImpls = listOf("my.impl.Impl"),
+                ),
+            ) { case ->
+                val apiResult = compileApi(*case.api.toTypedArray())
+                apiResult.exitCode shouldBe KotlinCompilation.ExitCode.OK
 
-    fun assertServiceFile(result: JvmCompilationResult, contractFqcn: List<String>, vararg expectedImpls: String) {
-        contractFqcn.forEach { fqcn ->
-            val lines = result.classLoader.readServiceFile(fqcn)?.lines()?.filter { it.isNotBlank() }?.sorted()
-            lines shouldBe expectedImpls.toList().sorted()
+                val implResult = compileImpl(apiResult, *case.impls.toTypedArray())
+                implResult.exitCode shouldBe KotlinCompilation.ExitCode.OK
+
+                assertServiceFile(implResult, case.contractFqcn, *case.expectedImpls.toTypedArray())
+            }
         }
-    }
+        //#endregion
 
-    // --- Happy path scenarios ---
-    data class ServiceCase(
-        val description: String,
-        val api: List<SourceFile>,
-        val impls: List<SourceFile>,
-        val contractFqcn: List<String>,
-        val expectedImpls: List<String>
-    )
+        //#region --- Error scenarios ---
+        data class ErrorCase(
+            val description: String,
+            val sources: List<SourceFile>,
+            val expectedMessage: String,
+            val expectedExitCode: KotlinCompilation.ExitCode = KotlinCompilation.ExitCode.COMPILATION_ERROR,
+        )
 
-    context("service generation happy paths") {
-        withData(
-            nameFn = { it.description },
-            // Kotlin API + Kotlin impl (nested)
-            ServiceCase(
-                "nested provider (Kotlin API + Kotlin impl)", api = listOf(
-                    SourceFile.kotlin(
-                        "Api.kt", """
-                    package my.api
-                    import com.github.eventhorizonlab.spi.ServiceContract
-                    interface Outer {
-                        @ServiceContract
-                        interface Inner
-                    }
-                """.trimIndent()
-                    )
-                ), impls = listOf(
-                    SourceFile.kotlin(
-                        "Impl.kt", """
-                    package my.impl
-                    import my.api.Outer.Inner
-                    import com.github.eventhorizonlab.spi.ServiceProvider
-                    class Impl {
-                        @ServiceProvider(Inner::class)
-                        class ImplInner : Inner
-                    }
-                """.trimIndent()
-                    )
-                ), contractFqcn = listOf("my.api.Outer\$Inner"), expectedImpls = listOf("my.impl.Impl\$ImplInner")
-            ),
-            // Kotlin API + Kotlin impl (cross-module)
-            ServiceCase(
-                "cross-module provider (Kotlin API + Kotlin impl)", api = listOf(
-                    SourceFile.kotlin(
-                        "Api.kt", """
-                    package my.api
-                    import com.github.eventhorizonlab.spi.ServiceContract
-                    @ServiceContract
-                    interface Contract
-                """.trimIndent()
-                    )
-                ), impls = listOf(
-                    SourceFile.kotlin(
-                        "Impl.kt", """
-                    package my.impl
-                    import my.api.Contract
-                    import com.github.eventhorizonlab.spi.ServiceProvider
-                    @ServiceProvider(Contract::class)
-                    class Impl : Contract
-                """.trimIndent()
-                    )
-                ), contractFqcn = listOf("my.api.Contract"), expectedImpls = listOf("my.impl.Impl")
-            ),
-            // Kotlin API + Java impl
-            ServiceCase(
-                "Kotlin API + Java impl", api = listOf(
-                    SourceFile.kotlin(
-                        "Api.kt", """
-                    package my.api
-                    import com.github.eventhorizonlab.spi.ServiceContract
-                    @ServiceContract
-                    interface Api
-                """.trimIndent()
-                    )
-                ), impls = listOf(
-                    SourceFile.java(
-                        "Impl.java", """
-                    package my.impl;
-                    import my.api.Api;
-                    import com.github.eventhorizonlab.spi.ServiceProvider;
-                    @ServiceProvider(Api.class)
-                    public class Impl implements Api {}
-                """.trimIndent()
-                    )
-                ), contractFqcn = listOf("my.api.Api"), expectedImpls = listOf("my.impl.Impl")
-            ),
-            // Java API + Kotlin impl
-            ServiceCase(
-                "Java API + Kotlin impl", api = listOf(
-                    SourceFile.java(
-                        "Api.java", """
-                    package my.api;
-                    import com.github.eventhorizonlab.spi.ServiceContract;
-                    @ServiceContract
-                    public interface Api {}
-                """.trimIndent()
-                    )
-                ), impls = listOf(
-                    SourceFile.kotlin(
-                        "Impl.kt", """
-                    package my.impl
-                    import my.api.Api
-                    import com.github.eventhorizonlab.spi.ServiceProvider
-                    @ServiceProvider(Api::class)
-                    class Impl : Api
-                """.trimIndent()
-                    )
-                ), contractFqcn = listOf("my.api.Api"), expectedImpls = listOf("my.impl.Impl")
-            ),
-            // Java API + Java impl
-            ServiceCase(
-                "Java API + Java impl", api = listOf(
-                    SourceFile.java(
-                        "Contract.java", """
-                    package my.api;
-                    import com.github.eventhorizonlab.spi.ServiceContract;
-                    @ServiceContract
-                    public interface Contract {}
-                """.trimIndent()
-                    )
-                ), impls = listOf(
-                    SourceFile.java(
-                        "Impl.java", """
-                    package my.impl;
-                    import my.api.Contract;
-                    import com.github.eventhorizonlab.spi.ServiceProvider;
-                    @ServiceProvider(Contract.class)
-                    public class Impl implements Contract {}
-                """.trimIndent()
-                    )
-                ), contractFqcn = listOf("my.api.Contract"), expectedImpls = listOf("my.impl.Impl")
-            ),
-            // Multiple providers
-            ServiceCase(
-                "multiple providers for same contract",
-                api = listOf(
-                    SourceFile.kotlin(
-                        "Api.kt", """
-                    package my.api
-                    import com.github.eventhorizonlab.spi.ServiceContract
-                    @ServiceContract
-                    interface Contract
-                """.trimIndent()
-                    )
+        context("error cases") {
+            withData(
+                nameFn = { it.description },
+                ErrorCase(
+                    "no provider for contract (Kotlin)",
+                    listOf(
+                        SourceFile.kotlin(
+                            "Api.kt",
+                            """
+                            package my.api
+                            import com.github.eventhorizonlab.spi.ServiceContract
+                            @ServiceContract
+                            interface LonelyContract
+                            """.trimIndent(),
+                        ),
+                    ),
+                    missingServiceProviderErrorMessage("my.api.LonelyContract"),
+                    KotlinCompilation.ExitCode.OK,
                 ),
-                impls = listOf(
-                    SourceFile.kotlin(
-                        "Impl1.kt", """
-                        package my.impl
-                        import my.api.Contract
-                        import com.github.eventhorizonlab.spi.ServiceProvider
-                        @ServiceProvider(Contract::class)
-                        class Impl1 : Contract
-                    """.trimIndent()
-                    ), SourceFile.kotlin(
-                        "Impl2.kt", """
-                        package my.impl
-                        import my.api.Contract
-                        import com.github.eventhorizonlab.spi.ServiceProvider
-                        @ServiceProvider(Contract::class)
-                        class Impl2 : Contract
-                    """.trimIndent()
-                    ), SourceFile.java(
-                        "Impl3.java", """
-                        package my.impl;
-                        import my.api.Contract;
-                        import com.github.eventhorizonlab.spi.ServiceProvider;
-                        @ServiceProvider(Contract.class)
-                        public class Impl3 implements Contract {}
-                    """.trimIndent()
-                    )
+                ErrorCase(
+                    "no provider for contract (Java)",
+                    listOf(
+                        SourceFile.java(
+                            "LonelyContract.java",
+                            """
+                            package my.api;
+                            import com.github.eventhorizonlab.spi.ServiceContract;
+                            @ServiceContract
+                            public interface LonelyContract {}
+                            """.trimIndent(),
+                        ),
+                    ),
+                    missingServiceProviderErrorMessage("my.api.LonelyContract"),
+                    KotlinCompilation.ExitCode.OK,
                 ),
-                contractFqcn = listOf("my.api.Contract"),
-                expectedImpls = listOf("my.impl.Impl1", "my.impl.Impl2", "my.impl.Impl3")
-            ), ServiceCase(
-                "provider implements multiple contracts (Kotlin)", api = listOf(
-                    SourceFile.kotlin(
-                        "Apis.kt", """
-                    package my.api
-                    import com.github.eventhorizonlab.spi.ServiceContract
-                    
-                    @ServiceContract
-                    interface Api
-                    
-                    @ServiceContract
-                    interface Api2
-                """.trimIndent()
-                    )
-                ), impls = listOf(
-                    SourceFile.kotlin(
-                        "Impl.kt", """
-                    package my.impl
-                    import my.api.Api
-                    import my.api.Api2
-                    import com.github.eventhorizonlab.spi.ServiceProvider
-                    @ServiceProvider(Api::class, Api2::class)
-                    class Impl : Api, Api2
-                """.trimIndent()
-                    )
-                ), contractFqcn = listOf("my.api.Api", "my.api.Api2"), expectedImpls = listOf("my.impl.Impl")
-            ), ServiceCase(
-                "provider implements multiple contracts (Java)", api = listOf(
-                    SourceFile.java(
-                        "Api.java", """
-                        package my.api;
-                        import com.github.eventhorizonlab.spi.ServiceContract;
-                        @ServiceContract
-                        public interface Api {}
-                    """.trimIndent()
-                    ), SourceFile.java(
-                        "Api2.java", """
-                        package my.api;
-                        import com.github.eventhorizonlab.spi.ServiceContract;
-                        @ServiceContract
-                        public interface Api2 {}
-                        """.trimIndent()
-                    )
-                ), impls = listOf(
-                    SourceFile.java(
-                        "Impl.java", """
-                        package my.impl;
-                        import my.api.Api;
-                        import my.api.Api2;
-                        import com.github.eventhorizonlab.spi.ServiceProvider;
-                        @ServiceProvider({Api.class, Api2.class})
-                        public class Impl implements Api, Api2 {}
-                        """.trimIndent()
-                    )
-                ), contractFqcn = listOf("my.api.Api", "my.api.Api2"), expectedImpls = listOf("my.impl.Impl")
-            ), ServiceCase(
-                "provider implements multiple contracts (Kotlin+Java)", api = listOf(
-                    SourceFile.kotlin(
-                        "Apis.kt", """
-                        package my.api
-                        import com.github.eventhorizonlab.spi.ServiceContract
-                        @ServiceContract
-                        interface Api
-                        @ServiceContract
-                        interface Api2
-                    """.trimIndent()
-                    )
-                ), impls = listOf(
-                    SourceFile.java(
-                        "Impl.java", """
+                ErrorCase(
+                    "implementation not annotated with @ServiceProvider (Kotlin)",
+                    listOf(
+                        SourceFile.kotlin(
+                            "Api.kt",
+                            """
+                            package my.api
+                            import com.github.eventhorizonlab.spi.ServiceContract
+                            @ServiceContract
+                            interface Contract
+                            """.trimIndent(),
+                        ),
+                        SourceFile.kotlin(
+                            "Impl.kt",
+                            """
+                            package my.impl
+                            import my.api.Contract
+                            class Impl : Contract
+                            """.trimIndent(),
+                        ),
+                    ),
+                    missingServiceProviderErrorMessage("my.api.Contract"),
+                ),
+                ErrorCase(
+                    "implementation not annotated with @ServiceProvider (Java)",
+                    listOf(
+                        SourceFile.java(
+                            "Contract.java",
+                            """
+                            package my.api;
+                            import com.github.eventhorizonlab.spi.ServiceContract;
+                            @ServiceContract
+                            public interface Contract {}
+                            """.trimIndent(),
+                        ),
+                        SourceFile.java(
+                            "Impl.java",
+                            """
                             package my.impl;
-                            import my.api.Api;
-                            import my.api.Api2;
+                            import my.api.Contract;
+                            public class Impl implements Contract {}
+                            """.trimIndent(),
+                        ),
+                    ),
+                    missingServiceProviderErrorMessage("my.api.Contract"),
+                ),
+                ErrorCase(
+                    "implementation not annotated with @ServiceProvider (Java+Kotlin)",
+                    listOf(
+                        SourceFile.java(
+                            "Contract.java",
+                            """
+                            package my.api;
+                            import com.github.eventhorizonlab.spi.ServiceContract;
+                            @ServiceContract
+                            public interface Contract {}
+                            """.trimIndent(),
+                        ),
+                        SourceFile.kotlin(
+                            "Impl.kt",
+                            """
+                            package my.impl
+                            import my.api.Contract
+                            class Impl : Contract
+                            """.trimIndent(),
+                        ),
+                    ),
+                    missingServiceProviderErrorMessage("my.api.Contract"),
+                ),
+                ErrorCase(
+                    "implementation not annotated with @ServiceProvider (Kotlin+Java)",
+                    listOf(
+                        SourceFile.kotlin(
+                            "Api.kt",
+                            """
+                            package my.api
+                            import com.github.eventhorizonlab.spi.ServiceContract
+                            @ServiceContract
+                            interface Contract
+                            """.trimIndent(),
+                        ),
+                        SourceFile.java(
+                            "Impl.java",
+                            """
+                            package my.impl;
+                            import my.api.Contract;
+                            public class Impl implements Contract {}
+                            """.trimIndent(),
+                        ),
+                    ),
+                    missingServiceProviderErrorMessage("my.api.Contract"),
+                ),
+                ErrorCase(
+                    "provider target not annotated with @ServiceContract (Kotlin)",
+                    listOf(
+                        SourceFile.kotlin(
+                            "Api.kt",
+                            """
+                            package my.api
+                            interface NotAContract
+                            """.trimIndent(),
+                        ),
+                        SourceFile.kotlin(
+                            "Impl.kt",
+                            """
+                            package my.impl
+                            import my.api.NotAContract
+                            import com.github.eventhorizonlab.spi.ServiceProvider
+                            @ServiceProvider(NotAContract::class)
+                            class Impl : NotAContract
+                            """.trimIndent(),
+                        ),
+                    ),
+                    "@ServiceProvider target my.api.NotAContract is not annotated with @ServiceContract",
+                ),
+                ErrorCase(
+                    "provider target not annotated with @ServiceContract (Java)",
+                    listOf(
+                        SourceFile.java(
+                            "NotAContract.java",
+                            """
+                            package my.api;
+                            public interface NotAContract {}
+                            """.trimIndent(),
+                        ),
+                        SourceFile.java(
+                            "Impl.java",
+                            """
+                            package my.impl;
+                            import my.api.NotAContract;
                             import com.github.eventhorizonlab.spi.ServiceProvider;
-                            @ServiceProvider({Api.class, Api2.class})
-                            public class Impl implements Api, Api2 {}
-                        """.trimIndent()
-                    )
-                ), contractFqcn = listOf("my.api.Api", "my.api.Api2"), expectedImpls = listOf("my.impl.Impl")
-            ), ServiceCase(
-                "provider implements multiple contracts (Java+Kotlin)", api = listOf(
-                    SourceFile.java(
-                        "Api.java", """
-                        package my.api;
-                        import com.github.eventhorizonlab.spi.ServiceContract;
-                        @ServiceContract
-                        public interface Api {}
-                    """.trimIndent()
-                    ), SourceFile.kotlin(
-                        "Api2.kt", """
-                        package my.api
-                        import com.github.eventhorizonlab.spi.ServiceContract
-                        @ServiceContract
-                        interface Api2
-                        """.trimIndent()
-                    )
-                ), impls = listOf(
-                    SourceFile.kotlin(
-                        "Impl.kt", """
-                        package my.impl
-                        import my.api.Api
-                        import my.api.Api2
-                        import com.github.eventhorizonlab.spi.ServiceProvider
-                        @ServiceProvider(Api::class, Api2::class)
-                        class Impl : Api, Api2
-                        """.trimIndent()
-                    )
-                ), contractFqcn = listOf("my.api.Api", "my.api.Api2"), expectedImpls = listOf("my.impl.Impl")
-            ), ServiceCase(
-                "Java generic API with Kotlin provider (type erasure check)", api = listOf(
-                    SourceFile.java(
-                        "Api.java", """
-                        package my.api;
-                        import com.github.eventhorizonlab.spi.ServiceContract;
-                        
-                        @ServiceContract
-                        public interface Api<T> {}
-                    """.trimIndent()
-                    )
-                ), impls = listOf(
-                    SourceFile.kotlin(
-                        "Impl.kt", """
-                        package my.impl
-                        import my.api.Api
-                        import com.github.eventhorizonlab.spi.ServiceProvider
-                        
-                        @ServiceProvider(Api::class)
-                        class Impl : Api<String>
-                    """.trimIndent()
-                    )
-                ), contractFqcn = listOf("my.api.Api"), expectedImpls = listOf("my.impl.Impl")
-            ), ServiceCase(
-                "Kotlin generic API with Java provider (type erasure check)", api = listOf(
-                    SourceFile.kotlin(
-                        "Api.kt", """
-                        package my.api
-                        import com.github.eventhorizonlab.spi.ServiceContract
-                        @ServiceContract
-                        interface Api<T>
-                        """.trimIndent()
-                    )
-                ), impls = listOf(
-                    SourceFile.java(
-                        "Impl.java", """
-                        package my.impl;
-                        import my.api.Api;
-                        import com.github.eventhorizonlab.spi.ServiceProvider;
-                        @ServiceProvider(Api.class)
-                        public class Impl implements Api<String> {}
-                        """.trimIndent()
-                    )
-                ), contractFqcn = listOf("my.api.Api"), expectedImpls = listOf("my.impl.Impl")
-            ), ServiceCase(
-                "Kotlin API with generic provider (type erasure check)", api = listOf(
-                    SourceFile.kotlin(
-                        "Api.kt", """
-                        package my.api
-                        import com.github.eventhorizonlab.spi.ServiceContract
-                        @ServiceContract
-                        interface Api<T>
-                        """.trimIndent()
-                    )
-                ), impls = listOf(
-                    SourceFile.kotlin(
-                        "Impl.kt", """
-                        package my.impl
-                        import my.api.Api
-                        import com.github.eventhorizonlab.spi.ServiceProvider
-                        @ServiceProvider(Api::class)
-                        class Impl : Api<String>
-                        """.trimIndent()
-                    )
-                ), contractFqcn = listOf("my.api.Api"), expectedImpls = listOf("my.impl.Impl")
-            ), ServiceCase(
-                "Java API with generic provider (type erasure check)", api = listOf(
-                    SourceFile.java(
-                        "Api.java", """
-                        package my.api;
-                        import com.github.eventhorizonlab.spi.ServiceContract;
-                        @ServiceContract
-                        public interface Api<T> {}
-                        """.trimIndent()
-                    )
+                            @ServiceProvider(NotAContract.class)
+                            public class Impl implements NotAContract {}
+                            """.trimIndent(),
+                        ),
+                    ),
+                    "@ServiceProvider target my.api.NotAContract is not annotated with @ServiceContract",
                 ),
-                impls = listOf(
-                    SourceFile.java(
-                        "Impl.java", """
-                        package my.impl;
-                        import my.api.Api;
-                        import com.github.eventhorizonlab.spi.ServiceProvider;
-                        @ServiceProvider(Api.class)
-                        public class Impl implements Api<String> {}
-                        """.trimIndent()
-                    )
+                ErrorCase(
+                    "provider target not annotated with @ServiceContract (kotlin+java)",
+                    listOf(
+                        SourceFile.kotlin(
+                            "Api.kt",
+                            """
+                            package my.api
+                            interface NotAContract
+                            """.trimIndent(),
+                        ),
+                        SourceFile.java(
+                            "Impl.java",
+                            """
+                            package my.impl;
+                            import my.api.NotAContract;
+                            import com.github.eventhorizonlab.spi.ServiceProvider;
+                            @ServiceProvider(NotAContract.class)
+                            public class Impl implements NotAContract {}
+                            """.trimIndent(),
+                        ),
+                    ),
+                    "@ServiceProvider target my.api.NotAContract is not annotated with @ServiceContract",
                 ),
-                contractFqcn = listOf("my.api.Api"), expectedImpls = listOf("my.impl.Impl")
-            )
-        ) { case ->
-            val apiResult = compileApi(*case.api.toTypedArray())
-            apiResult.exitCode shouldBe KotlinCompilation.ExitCode.OK
-
-            val implResult = compileImpl(apiResult, *case.impls.toTypedArray())
-            implResult.exitCode shouldBe KotlinCompilation.ExitCode.OK
-
-            assertServiceFile(implResult, case.contractFqcn, *case.expectedImpls.toTypedArray())
+                ErrorCase(
+                    "provider target not annotated with @ServiceContract (java+kotlin)",
+                    listOf(
+                        SourceFile.java(
+                            "NotAContract.java",
+                            """
+                            package my.api;
+                            public interface NotAContract {}
+                            """.trimIndent(),
+                        ),
+                        SourceFile.kotlin(
+                            "Impl.kt",
+                            """
+                            package my.impl
+                            import my.api.NotAContract
+                            import com.github.eventhorizonlab.spi.ServiceProvider
+                            @ServiceProvider(NotAContract::class)
+                            class Impl : NotAContract
+                            """.trimIndent(),
+                        ),
+                    ),
+                    "@ServiceProvider target my.api.NotAContract is not annotated with @ServiceContract",
+                ),
+            ) { case ->
+                val result = compile(case.sources)
+                result.exitCode shouldBe case.expectedExitCode
+                result.messages shouldContain case.expectedMessage
+            }
         }
-    }
+        //#endregion
 
-    // --- Error scenarios ---
-    data class ErrorCase(
-        val description: String, val sources: List<SourceFile>, val expectedMessage: String
-    )
+        //#region --- Normal scenarios ---
+        context("ServiceLoader integration") {
+            test("loads provider at runtime") {
+                val apiResult =
+                    compileApi(
+                        SourceFile.kotlin(
+                            "Api.kt",
+                            """
+                            package my.api
+                            import com.github.eventhorizonlab.spi.ServiceContract
+                            @ServiceContract
+                            interface GreetingService {
+                              fun greet(): String
+                            }
+                            """.trimIndent(),
+                        ),
+                    )
 
-    context("error cases") {
-        withData(
-            nameFn = { it.description }, ErrorCase(
-                "no provider for contract (Kotlin)", listOf(
-                    SourceFile.kotlin(
-                        "Api.kt", """
-                    package my.api
-                    import com.github.eventhorizonlab.spi.ServiceContract
-                    @ServiceContract
-                    interface LonelyContract
-                """.trimIndent()
+                val implResult =
+                    compileImpl(
+                        apiResult,
+                        SourceFile.kotlin(
+                            "Impl.kt",
+                            """
+                            package my.impl
+                            import my.api.GreetingService
+                            import com.github.eventhorizonlab.spi.ServiceProvider
+                            @ServiceProvider(GreetingService::class)
+                            class Impl : GreetingService {
+                              override fun greet() = "Hello, world!"
+                            }
+                            """.trimIndent(),
+                        ),
                     )
-                ), missingServiceProviderErrorMessage("my.api.LonelyContract")
-            ), ErrorCase(
-                "no provider for contract (Java)", listOf(
-                    SourceFile.java(
-                        "LonelyContract.java", """
-                    package my.api;
-                    import com.github.eventhorizonlab.spi.ServiceContract;
-                    @ServiceContract
-                    public interface LonelyContract {}
-                """.trimIndent()
-                    )
-                ), missingServiceProviderErrorMessage("my.api.LonelyContract")
-            ), ErrorCase(
-                "implementation not annotated with @ServiceProvider (Kotlin)", listOf(
-                    SourceFile.kotlin(
-                        "Api.kt", """
-                        package my.api
-                        import com.github.eventhorizonlab.spi.ServiceContract
-                        @ServiceContract
-                        interface Contract
-                    """.trimIndent()
-                    ), SourceFile.kotlin(
-                        "Impl.kt", """
-                        package my.impl
-                        import my.api.Contract
-                        class Impl : Contract
-                    """.trimIndent()
-                    )
-                ), missingServiceProviderErrorMessage("my.api.Contract")
-            ), ErrorCase(
-                "implementation not annotated with @ServiceProvider (Java)", listOf(
-                    SourceFile.java(
-                        "Contract.java", """
-                        package my.api;
-                        import com.github.eventhorizonlab.spi.ServiceContract;
-                        @ServiceContract
-                        public interface Contract {}
-                    """.trimIndent()
-                    ), SourceFile.java(
-                        "Impl.java", """
-                        package my.impl;
-                        import my.api.Contract;
-                        public class Impl implements Contract {}
-                    """.trimIndent()
-                    )
-                ), missingServiceProviderErrorMessage("my.api.Contract")
-            ), ErrorCase(
-                "implementation not annotated with @ServiceProvider (Java+Kotlin)", listOf(
-                    SourceFile.java(
-                        "Contract.java", """
-                        package my.api;
-                        import com.github.eventhorizonlab.spi.ServiceContract;
-                        @ServiceContract
-                        public interface Contract {}
-                    """.trimIndent()
-                    ), SourceFile.kotlin(
-                        "Impl.kt", """
-                        package my.impl
-                        import my.api.Contract
-                        class Impl : Contract
-                    """.trimIndent()
-                    )
-                ), missingServiceProviderErrorMessage("my.api.Contract")
-            ), ErrorCase(
-                "implementation not annotated with @ServiceProvider (Kotlin+Java)", listOf(
-                    SourceFile.kotlin(
-                        "Api.kt", """
-                        package my.api
-                        import com.github.eventhorizonlab.spi.ServiceContract
-                        @ServiceContract
-                        interface Contract
-                    """.trimIndent()
-                    ), SourceFile.java(
-                        "Impl.java", """
-                        package my.impl;
-                        import my.api.Contract;
-                        public class Impl implements Contract {}
-                    """.trimIndent()
-                    )
-                ), missingServiceProviderErrorMessage("my.api.Contract")
-            ), ErrorCase(
-                "provider target not annotated with @ServiceContract (Kotlin)", listOf(
-                    SourceFile.kotlin(
-                        "Api.kt", """
-                        package my.api
-                        interface NotAContract
-                    """.trimIndent()
-                    ), SourceFile.kotlin(
-                        "Impl.kt", """
-                        package my.impl
-                        import my.api.NotAContract
-                        import com.github.eventhorizonlab.spi.ServiceProvider
-                        @ServiceProvider(NotAContract::class)
-                        class Impl : NotAContract
-                    """.trimIndent()
-                    )
-                ), "@ServiceProvider target my.api.NotAContract is not annotated with @ServiceContract"
-            ), ErrorCase(
-                "provider target not annotated with @ServiceContract (Java)", listOf(
-                    SourceFile.java(
-                        "NotAContract.java", """
-                        package my.api;
-                        public interface NotAContract {}
-                    """.trimIndent()
-                    ), SourceFile.java(
-                        "Impl.java", """
-                        package my.impl;
-                        import my.api.NotAContract;
-                        import com.github.eventhorizonlab.spi.ServiceProvider;
-                        @ServiceProvider(NotAContract.class)
-                        public class Impl implements NotAContract {}
-                    """.trimIndent()
-                    )
-                ), "@ServiceProvider target my.api.NotAContract is not annotated with @ServiceContract"
-            ), ErrorCase(
-                "provider target not annotated with @ServiceContract (kotlin+java)", listOf(
-                    SourceFile.kotlin(
-                        "Api.kt", """
-                        package my.api
-                        interface NotAContract
-                    """.trimIndent()
-                    ), SourceFile.java(
-                        "Impl.java", """
-                        package my.impl;
-                        import my.api.NotAContract;
-                        import com.github.eventhorizonlab.spi.ServiceProvider;
-                        @ServiceProvider(NotAContract.class)
-                        public class Impl implements NotAContract {}
-                    """.trimIndent()
-                    )
-                ), "@ServiceProvider target my.api.NotAContract is not annotated with @ServiceContract"
-            ), ErrorCase(
-                "provider target not annotated with @ServiceContract (java+kotlin)", listOf(
-                    SourceFile.java(
-                        "NotAContract.java", """
-                        package my.api;
-                        public interface NotAContract {}
-                    """.trimIndent()
-                    ), SourceFile.kotlin(
-                        "Impl.kt", """
-                        package my.impl
-                        import my.api.NotAContract
-                        import com.github.eventhorizonlab.spi.ServiceProvider
-                        @ServiceProvider(NotAContract::class)
-                        class Impl : NotAContract
-                    """.trimIndent()
-                    )
-                ), "@ServiceProvider target my.api.NotAContract is not annotated with @ServiceContract"
-            )
-        ) { case ->
-            val result = compile(case.sources)
-            result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
-            result.messages shouldContain case.expectedMessage
+
+                implResult.exitCode shouldBe KotlinCompilation.ExitCode.OK
+
+                val urls =
+                    listOf(apiResult.outputDirectory, implResult.outputDirectory)
+                        .map { it.toURI().toURL() }
+                        .toTypedArray()
+                val cl = URLClassLoader(urls, null)
+
+                val contractClass = cl.loadClass("my.api.GreetingService")
+                val loader = ServiceLoader.load(contractClass, cl)
+
+                val implNames =
+                    loader
+                        .iterator()
+                        .asSequence()
+                        .map { it.javaClass.name }
+                        .toList()
+
+                implNames shouldContainExactly listOf("my.impl.Impl")
+
+                val impl = loader.first()
+                val implMethod = contractClass.methods.first { it.name == "greet" }
+                val result = implMethod.invoke(impl) as String
+                result shouldBe "Hello, world!"
+            }
         }
-    }
-
-    context("ServiceLoader integration") {
-        test("loads provider at runtime") {
-            val apiResult = compileApi(
-                SourceFile.kotlin(
-                    "Api.kt", """
-                    package my.api
-                    import com.github.eventhorizonlab.spi.ServiceContract
-                    @ServiceContract
-                    interface GreetingService {
-                      fun greet(): String
-                    }
-                    """.trimIndent()
-                )
-            )
-
-            val implResult = compileImpl(
-                apiResult, SourceFile.kotlin(
-                    "Impl.kt", """
-                    package my.impl
-                    import my.api.GreetingService
-                    import com.github.eventhorizonlab.spi.ServiceProvider
-                    @ServiceProvider(GreetingService::class)
-                    class Impl : GreetingService {
-                      override fun greet() = "Hello, world!"
-                    }
-                    """.trimIndent()
-                )
-            )
-
-            implResult.exitCode shouldBe KotlinCompilation.ExitCode.OK
-
-            val urls = listOf(apiResult.outputDirectory, implResult.outputDirectory)
-                .map { it.toURI().toURL() }
-                .toTypedArray()
-            val cl = URLClassLoader(urls, null)
-
-            val contractClass = cl.loadClass("my.api.GreetingService")
-            val loader = ServiceLoader.load(contractClass, cl)
-
-            val implNames = loader.iterator().asSequence().map { it.javaClass.name }.toList()
-
-            implNames shouldContainExactly listOf("my.impl.Impl")
-
-            val impl = loader.first()
-            val implMethod = contractClass.methods.first { it.name == "greet" }
-            val result = implMethod.invoke(impl) as String
-            result shouldBe "Hello, world!"
-        }
-    }
-})
+        //#endregion
+    })

--- a/modules/processor/src/test/kotlin/com/github/eventhorizonlab/spi/extensions/ProcessingEnvironmentExtensionsTests.kt
+++ b/modules/processor/src/test/kotlin/com/github/eventhorizonlab/spi/extensions/ProcessingEnvironmentExtensionsTests.kt
@@ -12,73 +12,88 @@ import javax.annotation.processing.RoundEnvironment
 import javax.lang.model.element.TypeElement
 
 @OptIn(ExperimentalCompilerApi::class)
-class ProcessingEnvironmentExtensionsTests : FunSpec({
+class ProcessingEnvironmentExtensionsTests :
+    FunSpec({
 
-    data class Case(
-        val description: String,
-        val source: SourceFile,
-        val fqName: String,
-        val expectedBinaryName: String
-    )
-
-    val cases = listOf(
-        Case(
-            "Top-level Kotlin class",
-            SourceFile.kotlin("TopLevel.kt", """
-                package com.test
-                class TopLevel
-            """.trimIndent()),
-            fqName = "com.test.TopLevel",
-            expectedBinaryName = "com.test.TopLevel"
-        ),
-        Case(
-            "Nested Kotlin class",
-            SourceFile.kotlin("Outer.kt", """
-                package com.test
-                class Outer {
-                    class Inner
-                }
-            """.trimIndent()),
-            fqName = "com.test.Outer.Inner",
-            expectedBinaryName = $$"com.test.Outer$Inner"
-        ),
-        Case(
-            "Inner (non-static) Java class",
-            SourceFile.java("OuterJava.java", """
-                package com.test;
-                public class OuterJava {
-                    public class InnerJava {}
-                }
-            """.trimIndent()),
-            fqName = "com.test.OuterJava.InnerJava",
-            expectedBinaryName = $$"com.test.OuterJava$InnerJava"
+        data class Case(
+            val description: String,
+            val source: SourceFile,
+            val fqName: String,
+            val expectedBinaryName: String,
         )
-    )
 
-    withData(nameFn = { it.description }, cases) { case ->
-        var actual: String? = null
+        val cases =
+            listOf(
+                Case(
+                    "Top-level Kotlin class",
+                    SourceFile.kotlin(
+                        "TopLevel.kt",
+                        """
+                        package com.test
+                        class TopLevel
+                        """.trimIndent(),
+                    ),
+                    fqName = "com.test.TopLevel",
+                    expectedBinaryName = "com.test.TopLevel",
+                ),
+                Case(
+                    "Nested Kotlin class",
+                    SourceFile.kotlin(
+                        "Outer.kt",
+                        """
+                        package com.test
+                        class Outer {
+                            class Inner
+                        }
+                        """.trimIndent(),
+                    ),
+                    fqName = "com.test.Outer.Inner",
+                    expectedBinaryName = $$"com.test.Outer$Inner",
+                ),
+                Case(
+                    "Inner (non-static) Java class",
+                    SourceFile.java(
+                        "OuterJava.java",
+                        """
+                        package com.test;
+                        public class OuterJava {
+                            public class InnerJava {}
+                        }
+                        """.trimIndent(),
+                    ),
+                    fqName = "com.test.OuterJava.InnerJava",
+                    expectedBinaryName = $$"com.test.OuterJava$InnerJava",
+                ),
+            )
 
-        val processor = object : AbstractProcessor() {
-            override fun init(processingEnv: ProcessingEnvironment) {
-                super.init(processingEnv)
-                val type = processingEnv.elementUtils.getTypeElement(case.fqName)
-                if (type != null) {
-                    actual = processingEnv.getStringifiedBinaryName(type)
+        withData(nameFn = { it.description }, cases) { case ->
+            var actual: String? = null
+
+            val processor =
+                object : AbstractProcessor() {
+                    override fun init(processingEnv: ProcessingEnvironment) {
+                        super.init(processingEnv)
+                        val type = processingEnv.elementUtils.getTypeElement(case.fqName)
+                        if (type != null) {
+                            actual = processingEnv.getStringifiedBinaryName(type)
+                        }
+                    }
+
+                    override fun process(
+                        annotations: MutableSet<out TypeElement>,
+                        roundEnv: RoundEnvironment,
+                    ) = false
                 }
-            }
-            override fun process(
-                annotations: MutableSet<out TypeElement>,
-                roundEnv: RoundEnvironment
-            ) = false
+
+            val result =
+                KotlinCompilation()
+                    .apply {
+                        sources = listOf(case.source)
+                        annotationProcessors = listOf(processor)
+                        inheritClassPath = true
+                    }.compile()
+
+            result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+            actual shouldBe case.expectedBinaryName
         }
-
-        val result = KotlinCompilation().apply {
-            sources = listOf(case.source)
-            annotationProcessors = listOf(processor)
-            inheritClassPath = true
-        }.compile()
-
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        actual shouldBe case.expectedBinaryName
-    }
-})
+    })


### PR DESCRIPTION
## 📌 Summary
<!-- Briefly describe the purpose of this PR and what it changes. -->
As seen in https://github.com/LMLiam/microsmith/pull/10, it is unexpected that a defined contract should cause compilation failure if there are no providers. However, it is still an expected case of failure if a provider does not annotate with @ServiceProvider. 

## 🔍 Related Issues / Tickets
<!-- Link to any related issues, discussions, or tickets. -->
No related issue.

## 🛠 Changes in Detail
<!-- List the key changes in this PR. -->
- Reworked the processor to ensure that
  - Compilation still fails if providers are specified without the annotation
  - Compilation does not fail if a contract is defined with no providers

## 🧩 Modules Affected
<!-- Tick all modules that are impacted by this change. -->
- [ ] spi-tooling-annotations
- [x] spi-tooling-processor
- [ ] Other:

## 📦 Versioning
<!-- 
If this PR is intended for a release:
- Ensure `version` in gradle.properties is greater than main.
If this PR is for a test snapshot:
- No manual version bump needed; CI will append `-SNAPSHOT-<pr>-<increment>`.
-->
- [x] Version bump applied (release PR)
- [ ] Snapshot only (PR build)

## 🧪 Testing
<!-- Describe how you tested your changes and how reviewers can reproduce them. -->
- Steps:
    1. Updated automatic tests, specifically the error cases to take in a result which allows us to control whether the expected compilation fails or succeeds.

## ✅ Checklist
- [x] Code builds locally without errors
- [x] All tests pass locally (`./gradlew kotest`)
- [x] Added/updated tests for new or changed logic
- [ ] Updated documentation / README if needed
- [x] No unrelated changes included

## 📜 Notes for Reviewers
<!-- Any extra context, caveats, or follow-up work for reviewers. -->
