### PR TITLE
ci(release): drop the "Release " prefix from release names

### DIFF
--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -49,7 +49,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ inputs.tag_name }}
-          name: Release ${{ inputs.tag_name }}
+          name: ${{ inputs.tag_name }}
           generate_release_notes: true
           files: build/libs/*
         env:


### PR DESCRIPTION
## Summary
GitHub Releases are currently titled `Release v0.1.X`. This drops the `Release ` prefix so a release is titled after its tag (e.g. `v0.1.22`).

## Change
`.github/workflows/release-and-publish.yml`:
```diff
-          name: Release ${{ inputs.tag_name }}
+          name: ${{ inputs.tag_name }}
```

## Notes
- The 16 existing releases (`v0.1.5`–`v0.1.21`, `0.1.4`) have already been renamed to drop the prefix.
- Per the repo's release model, this PR needs a `baseVersion` bump in `gradle.properties` to actually cut a release on merge (currently `0.1.21`, which is already tagged — see #28/#30).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated GitHub release naming to use tag names directly without additional prefixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->