### PR TITLE
docs: fix README and contributing typos

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -21,7 +21,7 @@ body:
   - type: input
     attributes:
       label: Environment
-      placeholder: "Paper 1.20.6, Kotlin 1.9.0"
+      placeholder: "JDK 21, Kotlin 2.0.0, Gradle 8.8, OS: Windows 11"
   - type: textarea
     attributes:
       label: Logs / Stacktrace

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,4 +108,4 @@ Releases are automated via GitHub Actions and occur when a push or merge is made
 ## Tips for Contributors
 - Keep changes focused - small, atomic PRs are easier to review
 - If you're unsure about an approach, open a Draft PR early for feedback
-- Think about future maintainers - clear code, clear cods, clear tests
+- Think about future maintainers - clear code, clear docs, clear tests

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Annotations Maven Central](https://img.shields.io/maven-central/v/io.github.eventhorizonlab/spi-tooling-annotations?color=blue)](https://central.sonatype.com/artifact/io.github.eventhorizonlab/spi-tooling-annotations)
 [![Processor Maven Central](https://img.shields.io/maven-central/v/io.github.eventhorizonlab/spi-tooling-processor?color=blue)](https://central.sonatype.com/artifact/io.github.eventhorizonlab/spi-tooling-processor) 
 [![Build](https://github.com/EventHorizonLab/SPI-Tooling/actions/workflows/release-and-publish.yml/badge.svg)](https://github.com/EventHorizonLab/SPI-Tooling/actions)  
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE.md)
 
 ---
 ## 📖 Overview
@@ -18,7 +18,7 @@ This is designed for:
 
 ---
 ## ✨ Features
-- **Annotation‑driven**: Mark your contracts with `@ServiceContract` and service implementations with `@ServiceProvider(Contract:class)`
+- **Annotation‑driven**: Mark your contracts with `@ServiceContract` and service implementations with `@ServiceProvider(MyContract::class)`
 - **Automatic `META-INF/services` generation** at compile time.
 - **Multi‑module aware**: Handles aggregation across modules without collisions.
 - **Deterministic output**: Stable ordering for reproducible builds.
@@ -181,4 +181,4 @@ Manual SPI file management is:
 - Error-prone (typos, missing entries)
 - Hard to maintain in multi-module setups
 - A barrier for new contributors
-`spi-tooling` makes it automatic, safe, and reproducible -- so you can focus on building features, not maintaing service files.
+`spi-tooling` makes it automatic, safe, and reproducible -- so you can focus on building features, not maintaining service files.


### PR DESCRIPTION
﻿## Summary
Fix small documentation and issue-template mistakes reported in #33.

## Related Issues / Tickets
- Closes #33

## Changes in Detail
- Fix the README license badge link to point to `LICENSE.md`.
- Correct the Kotlin `@ServiceProvider(MyContract::class)` example.
- Fix spelling in `README.md` and `CONTRIBUTING.md`.
- Remove the unrelated Paper server placeholder from the bug report template.

## Modules Affected
- [ ] spi-tooling-annotations
- [ ] spi-tooling-processor
- [x] Other: documentation and issue template

## Versioning
- [ ] Version bump applied (release PR)
- [x] Snapshot only (PR build)

## Testing
- Steps:
    1. Ran `rg` for the old typo/link/template strings.
    2. Confirmed no old strings remain.

## Checklist
- [ ] Code builds locally without errors
- [ ] All tests pass locally (`./gradlew kotest`)
- [ ] Added/updated tests for new or changed logic
- [x] Updated documentation / README if needed
- [x] No unrelated changes included

## Notes for Reviewers
This is a docs/template-only cleanup, so no Gradle test run was needed.
