### PR TITLE
docs: fix quick start Maven coordinates

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,26 +33,26 @@ This is designed for:
 Groovy DSL:
 ```groovy
 dependencies {
-    implementation "com.github.eventhorizonlab:spi-tooling-annotations:<version>"
+    implementation "io.github.eventhorizonlab:spi-tooling-annotations:<version>"
     
     // --- BELOW ONLY REQUIRED FOR PROJECTS USING @ServiceProvider ---
     // Kotlin projects:
-    kapt "com.github.eventhorizonlab:spi-tooling-processor:<version>"
+    kapt "io.github.eventhorizonlab:spi-tooling-processor:<version>"
     
     // Java projects:
-    annotationProcessor("com.github.eventhorizonlab:spi-tooling:<version>")
+    annotationProcessor("io.github.eventhorizonlab:spi-tooling-processor:<version>")
 }
 ```
 Gradle kts:
 ```kotlin
 dependencies {
-    implementation("com.github.eventhorizonlab:spi-tooling-annotations:<version>")
+    implementation("io.github.eventhorizonlab:spi-tooling-annotations:<version>")
     
     // --- BELOW ONLY REQUIRED FOR PROJECTS USING @ServiceProvider ---
     // Kotlin projects:
-    kapt("com.github.eventhorizonlab:spi-tooling-processor:<version>")
+    kapt("io.github.eventhorizonlab:spi-tooling-processor:<version>")
     // Java projects:
-    annotationProcessor("com.github.eventhorizonlab:spi-tooling-processor:<version>")
+    annotationProcessor("io.github.eventhorizonlab:spi-tooling-processor:<version>")
 }
 ```
 ➡️ See [Kapt](https://kotlinlang.org/docs/kapt.html#0) for more information


### PR DESCRIPTION
## Summary
- Updates the README Quick Start dependency snippets to use `io.github.eventhorizonlab`.
- Uses `spi-tooling-processor` for the Groovy `annotationProcessor` example, matching the published processor artifact.

## Related Issue
- Closes #22

## Validation
- Checked `gradle.properties`: `group=io.github.eventhorizonlab`.
- Checked `build.gradle`: Maven publishing coordinates use `rootProject.group` and `${rootProject.name}-${project.name}`.
- Checked `settings.gradle`: published subprojects are `annotations` and `processor`.
- Checked Maven Central metadata plus `0.1.23` POM/JAR URLs for:
  - `io.github.eventhorizonlab:spi-tooling-annotations`
  - `io.github.eventhorizonlab:spi-tooling-processor`
- Confirmed stale Maven Central paths return 404 for `com.github.eventhorizonlab:*` and `io.github.eventhorizonlab:spi-tooling`.
- Ran `git diff --check`.

I also tried a minimal Gradle dependency-resolution project with the corrected coordinates, but this local host has no Java runtime installed, so Gradle could not start.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README Gradle build configuration examples to reference current Maven repository coordinates.
  * Corrected annotation processor dependency identifier and synchronized both Groovy DSL and Kotlin DSL code examples with accurate dependency names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->