### PR TITLE
docs: fix README and contributing typos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to SPI-Tooling
 
-Firstly, thank you for taking the time contribute!
+Firstly, thank you for taking the time to contribute!
 SPI-Tooling exists to make service loading easier, and your ideas, fixes and improvements help make that possible.
 
 This guide will walk you through how to set up your environment, make changes, and submit them in a way that keeps the project reproducible and contributor-friendly.
@@ -108,4 +108,4 @@ Releases are automated via GitHub Actions and occur when a push or merge is made
 ## Tips for Contributors
 - Keep changes focused - small, atomic PRs are easier to review
 - If you're unsure about an approach, open a Draft PR early for feedback
-- Think about future maintainers - clear code, clear cods, clear tests
+- Think about future maintainers - clear code, clear docs, clear tests

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Annotations Maven Central](https://img.shields.io/maven-central/v/io.github.eventhorizonlab/spi-tooling-annotations?color=blue)](https://central.sonatype.com/artifact/io.github.eventhorizonlab/spi-tooling-annotations)
 [![Processor Maven Central](https://img.shields.io/maven-central/v/io.github.eventhorizonlab/spi-tooling-processor?color=blue)](https://central.sonatype.com/artifact/io.github.eventhorizonlab/spi-tooling-processor) 
 [![Build](https://github.com/EventHorizonLab/SPI-Tooling/actions/workflows/release-and-publish.yml/badge.svg)](https://github.com/EventHorizonLab/SPI-Tooling/actions)  
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE.md)
 
 ---
 ## 📖 Overview
@@ -18,7 +18,7 @@ This is designed for:
 
 ---
 ## ✨ Features
-- **Annotation‑driven**: Mark your contracts with `@ServiceContract` and service implementations with `@ServiceProvider(Contract:class)`
+- **Annotation‑driven**: Mark your contracts with `@ServiceContract` and service implementations with `@ServiceProvider(Contract::class)`
 - **Automatic `META-INF/services` generation** at compile time.
 - **Multi‑module aware**: Handles aggregation across modules without collisions.
 - **Deterministic output**: Stable ordering for reproducible builds.
@@ -181,4 +181,4 @@ Manual SPI file management is:
 - Error-prone (typos, missing entries)
 - Hard to maintain in multi-module setups
 - A barrier for new contributors
-`spi-tooling` makes it automatic, safe, and reproducible -- so you can focus on building features, not maintaing service files.
+`spi-tooling` makes it automatic, safe, and reproducible -- so you can focus on building features, not maintaining service files.


### PR DESCRIPTION
## Summary
- fix the README license badge target
- correct the ServiceProvider attribute example
- clean up small README and CONTRIBUTING typos

Closes #33

## Validation
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved contributor guidance wording and fixed a typo in the contribution tips.
  * Corrected the license badge link in the README.
  * Fixed a Kotlin example snippet and several minor wording/spelling issues in the project overview.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->